### PR TITLE
Fix for remote exception bug

### DIFF
--- a/src/callme/proxy.py
+++ b/src/callme/proxy.py
@@ -137,14 +137,15 @@ class Proxy(object):
 		
 		self._wait_for_result()
 		
-		if self.response.exception_raised:
-			raise self.response.result
-		
 		self.logger.debug('Result: %s' % repr(self.response.result))
 		res = self.response.result
 		self.response.result = None
 		self.is_received = False
-		return res
+
+		if self.response.exception_raised:
+                        raise res
+                else:
+                        return res
 		
 	def _wait_for_result(self):
 		"""


### PR DESCRIPTION
The is_received flag was not reset to false in Proxy.__request when throwing a remote exception.  This caused all subsequent remote method calls to throw the same exception again.
