### PR TITLE
Response exception handling simplified

### DIFF
--- a/src/callme/protocol.py
+++ b/src/callme/protocol.py
@@ -24,12 +24,13 @@ class RpcResponse(object):
     back to the client
 
     :keyword result: the result of the rpc call on the server
-    :keyword exception_raised: if the result is an exception which was
-    raised during the execution of the rpc call on the server
     """
-    def __init__(self, result, exception_raised=False):
+    def __init__(self, result):
         self.result = result
-        self.exception_raised = exception_raised
+
+    @property
+    def is_exception(self):
+        return isinstance(self.result, BaseException)
 
 
 class ConnectionError(Exception):

--- a/src/callme/proxy.py
+++ b/src/callme/proxy.py
@@ -135,14 +135,12 @@ class Proxy(object):
         self._wait_for_result()
 
         self.logger.debug('Result: %s' % repr(self.response.result))
-        res = self.response.result
-        self.response.result = None
         self.is_received = False
 
-        if self.response.exception_raised:
+        res = self.response.result
+        if self.response.is_exception:
             raise res
-        else:
-            return res
+        return res
 
     def _wait_for_result(self):
         """

--- a/src/callme/server.py
+++ b/src/callme/server.py
@@ -121,7 +121,7 @@ class Server(object):
             rpc_resp = RpcResponse(result)
         except Exception as e:
             self.logger.debug('exception happened')
-            rpc_resp = RpcResponse(e, exception_raised=True)
+            rpc_resp = RpcResponse(e)
 
         message.ack()
 
@@ -174,7 +174,7 @@ class Server(object):
                 rpc_resp = RpcResponse(result)
             except Exception as e:
                 self.logger.debug('exception happened')
-                rpc_resp = RpcResponse(e, exception_raised=True)
+                rpc_resp = RpcResponse(e)
 
             result_queue.put(ResultSet(rpc_resp,
                                        message.properties['correlation_id'],


### PR DESCRIPTION
This change simplifies the response exception handling a little bit, so
there is no need to pass 'exception_raised' parameter explicitly.

Please, take a look, I think this would be useful for you. Thanks!
