### PR TITLE
Correct kombu version requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     version=callme.__version__,
     packages=find_packages('src'),
     package_dir={'': 'src'},
-    install_requires=['kombu>=1.2.1'],
+    install_requires=['kombu>=1.2.1,<3.0.0'],
 
     # metadata for upload to PyPI
     author=callme.__author__,


### PR DESCRIPTION
Since callme currently is not compatible with kombu>=3.0.0, I've add proper package requirements to setup.py.

Please, take a look.
