### PR TITLE
Remove 'direct' type exchange parameter

### DIFF
--- a/src/callme/proxy.py
+++ b/src/callme/proxy.py
@@ -57,7 +57,7 @@ class Proxy(object):
         my_uuid = gen_unique_id()
         self.reply_id = "client_"+amqp_user+"_ex_" + my_uuid
         LOG.debug("Queue ID: {0}".format(self.reply_id))
-        src_exchange = Exchange(self.reply_id, "direct", durable=False,
+        src_exchange = Exchange(self.reply_id, durable=False,
                                 auto_delete=True)
         src_queue = Queue("client_"+amqp_user+"_queue_"+my_uuid, durable=False,
                           exchange=src_exchange, auto_delete=True)
@@ -118,7 +118,7 @@ class Proxy(object):
         """
         LOG.debug("Request: {!r}; Params: {!r}".format(methodname, params))
 
-        target_exchange = Exchange("server_"+self.server_id+"_ex", 'direct',
+        target_exchange = Exchange("server_"+self.server_id+"_ex",
                                    durable=False, auto_delete=True)
         self.producer = Producer(channel=self.channel,
                                  exchange=target_exchange,

--- a/src/callme/server.py
+++ b/src/callme/server.py
@@ -51,7 +51,7 @@ class Server(object):
         self.is_stopped = True
         self.func_dict = {}
         self.result_queue = queue.Queue()
-        target_exchange = Exchange("server_"+server_id+"_ex", "direct",
+        target_exchange = Exchange("server_"+server_id+"_ex",
                                    durable=False, auto_delete=True)
         self.target_queue = Queue("server_"+server_id+"_queue",
                                   exchange=target_exchange, auto_delete=True,
@@ -127,7 +127,7 @@ class Server(object):
 
         LOG.debug("Publish response")
         # producer
-        src_exchange = Exchange(message.properties['reply_to'], 'direct',
+        src_exchange = Exchange(message.properties['reply_to'],
                                 durable=False, auto_delete=True)
         self.producer = Producer(self.publish_channel, src_exchange,
                                  auto_declare=False)
@@ -264,7 +264,7 @@ class Publisher(Thread):
                 result_set = self.result_queue.get(block=True, timeout=1)
                 LOG.debug("Publish response: {!r}".format(result_set))
 
-                src_exchange = Exchange(result_set.reply_to, "direct",
+                src_exchange = Exchange(result_set.reply_to,
                                         durable=False, auto_delete=True)
                 producer = Producer(self.channel, src_exchange,
                                     auto_declare=False)


### PR DESCRIPTION
Exchange type 'direct' is used by default, so there is
no need to specify it explicitly.
