### PR TITLE
Proxy timeout handling improved

### DIFF
--- a/src/callme/exceptions.py
+++ b/src/callme/exceptions.py
@@ -6,3 +6,8 @@ class CallmeException(Exception):
 class ConnectionError(CallmeException):
     """Raised when failed to connect to AMQP"""
     pass
+
+
+class RpcTimeout(CallmeException):
+    """Raise when rpc request timed out"""
+    pass

--- a/src/callme/proxy.py
+++ b/src/callme/proxy.py
@@ -6,9 +6,11 @@ Classes
 """
 
 from kombu import BrokerConnection, Exchange, Queue, Consumer, Producer
+import exceptions
 import uuid
 import logging
 import socket
+import time
 from kombu.utils import gen_unique_id
 
 from protocol import RpcRequest
@@ -149,17 +151,18 @@ class Proxy(object):
         occurred. If a timeout occurs a `socket.timeout` exception will be
         raised.
         """
-        seconds_elapsed = 0
+        elapsed = 0
+        start_time = time.time()
         while not self.is_received:
             try:
-                LOG.debug("Draining events... timeout={0}, counter={1}".format
-                          (self.timeout, seconds_elapsed))
+                LOG.debug("Draining events... timeout: {0}, elapsed: {1}"
+                          .format(self.timeout, elapsed))
                 self.connection.drain_events(timeout=1)
             except socket.timeout:
                 if self.timeout > 0:
-                    seconds_elapsed = seconds_elapsed + 1
-                    if seconds_elapsed > self.timeout:
-                        raise socket.timeout()
+                    elapsed = time.time() - start_time
+                    if elapsed > self.timeout:
+                       raise exceptions.RpcTimeout("RPC Request timeout")
 
     def __getattr__(self, name):
         """

--- a/src/callme/tests/test_actions.py
+++ b/src/callme/tests/test_actions.py
@@ -6,6 +6,8 @@ import logging
 import socket
 import sys
 import unittest
+
+from callme import exceptions
 from threading import Thread
 
 
@@ -187,7 +189,7 @@ class ActionsTestCase(unittest.TestCase):
                              amqp_user='guest',
                              amqp_password='guest')
 
-        self.assertRaises(socket.timeout,
+        self.assertRaises(exceptions.RpcTimeout,
                           proxy.use_server('fooserver', timeout=1).madd, 1, 2)
 
     def test_remote_exception(self):


### PR DESCRIPTION
- Wait for result loop corrected to work with real time,
  that is more accurate then working with one-second loop
  cycles.
- RpcTimeout exception added to raise it instead of the
  socket.timeout that internal one and should not be raised
  outside.
