### PR TITLE
Corrected client example.

### DIFF
--- a/doc/source/introduction.rst
+++ b/doc/source/introduction.rst
@@ -38,7 +38,8 @@ result::
 
     import callme
 
-    proxy = callme.Proxy(amqp_host='localhost')
+    proxy = callme.Proxy(server_id='fooserver',
+                         amqp_host='localhost')
 
     print proxy.use_server('fooserver').add(1, 1)
 


### PR DESCRIPTION
Need server_id, default given example is failing while trying to run it.
"amqp_host" is a optional argument with default value as "localhost", but server_id is mandatory argument, which should be same server_id as given while creating server.